### PR TITLE
First attempt at CSRF support

### DIFF
--- a/login/csrf/csrf.go
+++ b/login/csrf/csrf.go
@@ -1,0 +1,57 @@
+package csrf
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math/rand"
+)
+
+var TokenSize = 18
+var EncodedTokenSize = 24
+var DoubleEncodedTokenSize = 32
+
+// GenerateToken generates a new random token that can be used as a CSRF token. Ideally,
+// a unique token for each session should be generated. On can use the masking technique
+// to generate a unique token for each request, that can still be verified against a
+// session-unique token.
+func GenerateToken() string {
+	var b []byte = make([]byte, TokenSize)
+
+	rand.Read(b)
+
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// Mask can be used to mask a session-wide token into a unique CSRF token for each request.
+func Mask(sessionToken string) string {
+	toMask := GenerateToken()
+
+	return base64.StdEncoding.EncodeToString(xor([]byte(sessionToken), []byte(toMask))) + string(toMask)
+}
+
+func Unmask(token string) (string, error) {
+	mask := token[DoubleEncodedTokenSize:]
+
+	masked, err := base64.StdEncoding.DecodeString(token[:DoubleEncodedTokenSize])
+	if err != nil {
+		return "", fmt.Errorf("could not decode: %w", err)
+	}
+
+	return string(xor([]byte(mask), masked)), nil
+}
+
+func xor(x []byte, y []byte) (result []byte) {
+	var n = len(x)
+
+	if len(y) < n {
+		n = len(y)
+	}
+
+	result = make([]byte, n)
+
+	for i := 0; i < n; i++ {
+		result[i] = x[i] ^ y[i]
+	}
+
+	return
+}

--- a/login/csrf/csrf.go
+++ b/login/csrf/csrf.go
@@ -32,6 +32,8 @@ func Mask(sessionToken string) string {
 	return base64.StdEncoding.EncodeToString(xor([]byte(sessionToken), []byte(toMask))) + string(toMask)
 }
 
+// Unmask extracts a potential session-wide token from a masked CSRF token. It returns an error
+// if the token is not of the correct length or if it contains illegal base64 characters.
 func Unmask(token string) (string, error) {
 	n := len(token)
 
@@ -49,6 +51,7 @@ func Unmask(token string) (string, error) {
 	return string(xor([]byte(mask), masked)), nil
 }
 
+// xor is a small utility function to xor two byte slices.
 func xor(x []byte, y []byte) (result []byte) {
 	var n = len(x)
 

--- a/login/csrf/csrf.go
+++ b/login/csrf/csrf.go
@@ -33,7 +33,9 @@ func Mask(sessionToken string) string {
 }
 
 func Unmask(token string) (string, error) {
-	if len(token) != DoubleEncodedTokenSize+EncodedTokenSize {
+	n := len(token)
+
+	if n != DoubleEncodedTokenSize+EncodedTokenSize {
 		return "", ErrInvalidLength
 	}
 

--- a/login/csrf/csrf.go
+++ b/login/csrf/csrf.go
@@ -2,6 +2,7 @@ package csrf
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math/rand"
 )
@@ -9,6 +10,8 @@ import (
 var TokenSize = 18
 var EncodedTokenSize = 24
 var DoubleEncodedTokenSize = 32
+
+var ErrInvalidLength = errors.New("invalid length")
 
 // GenerateToken generates a new random token that can be used as a CSRF token. Ideally,
 // a unique token for each session should be generated. On can use the masking technique
@@ -30,6 +33,10 @@ func Mask(sessionToken string) string {
 }
 
 func Unmask(token string) (string, error) {
+	if len(token) != DoubleEncodedTokenSize+EncodedTokenSize {
+		return "", ErrInvalidLength
+	}
+
 	mask := token[DoubleEncodedTokenSize:]
 
 	masked, err := base64.StdEncoding.DecodeString(token[:DoubleEncodedTokenSize])

--- a/login/csrf/csrf_test.go
+++ b/login/csrf/csrf_test.go
@@ -1,6 +1,7 @@
 package csrf
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -60,17 +61,25 @@ func TestUnmask(t *testing.T) {
 			},
 			want: token,
 		},
+		{
+			name: "invalid length",
+			args: args{
+				token: "mytoken",
+			},
+			want:    "",
+			wantErr: ErrInvalidLength,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotErr := Unmask(tt.args.token)
 
-			if gotErr != tt.wantErr {
-				t.Errorf("Unmask() = %v, want %v", got, tt.want)
+			if gotErr != nil && !errors.Is(gotErr, tt.wantErr) {
+				t.Errorf("Unmask() error = %v, want %v", gotErr, tt.wantErr)
 			}
 
 			if got != tt.want {
-				t.Errorf("Unmask() error = %v, want %v", gotErr, tt.wantErr)
+				t.Errorf("Unmask() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/login/csrf/csrf_test.go
+++ b/login/csrf/csrf_test.go
@@ -1,0 +1,77 @@
+package csrf
+
+import (
+	"testing"
+)
+
+func TestGenerateToken(t *testing.T) {
+	got := GenerateToken()
+	gotLength := len(got)
+	wantLength := EncodedTokenSize
+
+	if gotLength != wantLength {
+		t.Errorf("GenerateToken() length = %v, want %v", gotLength, wantLength)
+	}
+}
+
+func TestMask(t *testing.T) {
+	type args struct {
+		sessionToken string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantLength int
+	}{
+		{
+			name: "session token",
+			args: args{
+				sessionToken: GenerateToken(),
+			},
+			wantLength: DoubleEncodedTokenSize + EncodedTokenSize,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.args.sessionToken); len(got) != tt.wantLength {
+				t.Errorf("Mask() = %v, want %v", len(got), tt.wantLength)
+			}
+		})
+	}
+}
+
+func TestUnmask(t *testing.T) {
+	var token = GenerateToken()
+	var mask = Mask(token)
+
+	type args struct {
+		token string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr error
+	}{
+		{
+			name: "successful unmask",
+			args: args{
+				token: mask,
+			},
+			want: token,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := Unmask(tt.args.token)
+
+			if gotErr != tt.wantErr {
+				t.Errorf("Unmask() = %v, want %v", got, tt.want)
+			}
+
+			if got != tt.want {
+				t.Errorf("Unmask() error = %v, want %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}

--- a/login/form.go
+++ b/login/form.go
@@ -17,6 +17,9 @@ type loginForm struct {
 
 	// fs is the file system to retrieve the login html page from
 	fs fs.FS
+
+	// csrfToken is a mandatory CSRF token, which needs to be filled from the user's session
+	csrfToken string
 }
 
 func (form loginForm) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -29,6 +32,7 @@ func (form loginForm) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = tmpl.Execute(w, map[string]interface{}{
 		"ErrorMessage": form.errorMessage,
 		"ReturnURL":    form.returnURL,
+		"CSRFToken":    form.csrfToken,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/login/login.go
+++ b/login/login.go
@@ -153,7 +153,7 @@ func (h *handler) updateSession(w http.ResponseWriter, session *session, user *U
 
 	http.SetCookie(w, session.Cookie(h.baseURL))
 
-	h.log.Printf("Updating session with id %s to user %s", session.ID, user.Name)
+	h.log.Printf("Associating session with id %s to user %s", session.ID, user.Name)
 }
 
 // removeSession removes an (expired) session from the session storage

--- a/login/login.go
+++ b/login/login.go
@@ -179,17 +179,17 @@ func (h *handler) doLoginGet(w http.ResponseWriter, r *http.Request) {
 	// Retrieve an optional return URL. Will default to the handler's base URL
 	returnURL = h.parseReturnURL(r)
 
+	// Extract our session (or potentially start a new one)
+	session = h.extractSession(w, r)
+
 	// Prepare the login form
-	form = loginForm{returnURL: returnURL, fs: h.files}
+	form = loginForm{returnURL: returnURL, fs: h.files, csrfToken: session.CSRFToken}
 
 	// Check, if we have an additional failure message
 	if r.URL.Query().Has("failed") {
 		// We display the login page with an error message
 		form.errorMessage = "Invalid credentials"
 	}
-
-	// Extract our session (or potentially start a new one)
-	session = h.extractSession(w, r)
 
 	// At this point, we either have a (new) anonymous session or an existing user session
 	if session.Anonymous() {

--- a/login/login.html
+++ b/login/login.html
@@ -55,10 +55,11 @@
         <div class="error">{{.ErrorMessage}}</div>
         {{end}}
         <form action="/login" method="POST" autocomplete="off">
+            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+            <input type="hidden" name="return_url" value="{{.ReturnURL}}">
+
             <p><input type="text" id="username" name="username" placeholder="Username" /></p>
             <p><input type="password" id="password" name="password" placeholder="Password" /></p>
-
-            <input type="hidden" name="return_url" value="{{.ReturnURL}}">
 
             <input type="submit" value="Login">
         </form>

--- a/login/login_test.go
+++ b/login/login_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	oauth2 "github.com/oxisto/oauth2go"
+	"github.com/oxisto/oauth2go/login/csrf"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -168,6 +169,7 @@ func Test_handler_doLoginGet(t *testing.T) {
 
 func Test_handler_doLoginPost(t *testing.T) {
 	var hash, _ = bcryptHasher{}.GenerateFromPassword([]byte("admin"), bcrypt.DefaultCost)
+	var token = csrf.GenerateToken()
 
 	type fields struct {
 		sessions map[string]*session
@@ -193,7 +195,7 @@ func Test_handler_doLoginPost(t *testing.T) {
 				sessions: map[string]*session{
 					"mySession": {
 						ID:        "mySession",
-						CSRFToken: "myToken",
+						CSRFToken: token,
 						ExpireAt:  time.Now().Add(5 * time.Hour),
 					},
 				},
@@ -211,7 +213,7 @@ func Test_handler_doLoginPost(t *testing.T) {
 						"Cookie": []string{"id=mySession"},
 					},
 					PostForm: url.Values{
-						"csrf_token": []string{"myToken"},
+						"csrf_token": []string{csrf.Mask(token)},
 						"username":   []string{"admin"},
 						"password":   []string{"admin"},
 					},
@@ -229,7 +231,7 @@ func Test_handler_doLoginPost(t *testing.T) {
 				sessions: map[string]*session{
 					"mySession": {
 						ID:        "mySession",
-						CSRFToken: "myToken",
+						CSRFToken: token,
 						ExpireAt:  time.Now().Add(5 * time.Hour),
 					},
 				},
@@ -247,7 +249,7 @@ func Test_handler_doLoginPost(t *testing.T) {
 						"Cookie": []string{"id=mySession"},
 					},
 					PostForm: url.Values{
-						"csrf_token": []string{"myToken"},
+						"csrf_token": []string{csrf.Mask(token)},
 						"username":   []string{"notadmin"},
 						"password":   []string{"admin"},
 					},

--- a/server.go
+++ b/server.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -134,33 +133,6 @@ func (srv *AuthorizationServer) doClientCredentialsFlow(w http.ResponseWriter, r
 	}
 
 	writeJSON(w, &token)
-}
-
-// handleAuthorize implements the authorization endpoint (see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1).
-func (srv *AuthorizationServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
-	var (
-		err         error
-		clientID    string
-		redirectURI string
-		state       string
-		query       url.Values
-	)
-
-	query = r.URL.Query()
-
-	if query.Get("response_type") != "code" {
-		Error(w, "TODO", http.StatusBadRequest)
-		return
-	}
-
-	if clientID = query.Get("client_id"); clientID == "" {
-		Error(w, "invalid_client", http.StatusBadRequest)
-	}
-
-	redirectURI = query.Get("redirect_uri")
-	state = query.Get("state")
-
-	fmt.Printf("%+v %+v %+v", err, redirectURI, state)
 }
 
 func (srv *AuthorizationServer) handleJWKS(w http.ResponseWriter, r *http.Request) {

--- a/server_test.go
+++ b/server_test.go
@@ -84,14 +84,14 @@ func TestAuthorizationServer_retrieveClient(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Missing authorization",
+			name: "missing authorization",
 			args: args{
 				r: &http.Request{},
 			},
 			wantErr: true,
 		},
 		{
-			name: "No base64 basic authorization",
+			name: "no base64 basic authorization",
 			args: args{
 				r: &http.Request{
 					Header: http.Header{
@@ -102,7 +102,7 @@ func TestAuthorizationServer_retrieveClient(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Wrong basic authorization",
+			name: "wrong basic authorization",
 			args: args{
 				r: &http.Request{
 					Header: http.Header{
@@ -113,7 +113,7 @@ func TestAuthorizationServer_retrieveClient(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Invalid client credentials",
+			name: "invalid client credentials",
 			args: args{
 				r: &http.Request{
 					Header: http.Header{
@@ -124,7 +124,7 @@ func TestAuthorizationServer_retrieveClient(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Valid client credentials",
+			name: "valid client credentials",
 			fields: fields{
 				clients: []*Client{
 					{


### PR DESCRIPTION
This introduces CSRF support for the login server. This required several changes:

- A new (anonymous) session is now started using a `GET` request to `/login`. This also creates a new CSRF token, tied to the session. In order to improve security, a masked version of this token is used in any request / login page. See https://denvaar.github.io/articles/csrf_tokens_with_phoenix.html for a good explanation.
- The `POST` request to `/login` now compares this CSRF token against the one stored in the session. This requires the user to first establish a session, before calling the `POST` request.