### PR TITLE
Using `RawURLEncoding` instead of `RawStdEncoding` in `GenerateSecret`

### DIFF
--- a/server.go
+++ b/server.go
@@ -406,7 +406,7 @@ func GenerateSecret() string {
 
 	rand.Read(b)
 
-	return base64.RawStdEncoding.EncodeToString(b)
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 func GenerateCodeChallenge(verifier string) string {


### PR DESCRIPTION
This might fix issues with random secrets, such as codes that contain problematic characters when transmitting them in a URL.