### PR TITLE
Fixed issue with `kid` order confusion

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -47,7 +47,7 @@ func TestIntegration(t *testing.T) {
 	jwtoken, err := jwt.ParseWithClaims(token.AccessToken, &jwt.RegisteredClaims{}, func(t *jwt.Token) (interface{}, error) {
 		kid, _ := strconv.ParseInt(t.Header["kid"].(string), 10, 64)
 
-		return srv.PublicKeys()[kid], nil
+		return srv.PublicKeys()[int(kid)], nil
 	})
 	if err != nil {
 		t.Errorf("Error while retrieving a token: %v", err)

--- a/server_test.go
+++ b/server_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -46,7 +47,7 @@ var testChallenge = GenerateCodeChallenge(testVerifier)
 // testRefreshTokenClientKID1MockSingingKey is a valid refresh token signed by mockSigningKey with the KID 1
 var testRefreshTokenClientKID1MockSingingKey string
 
-func init() {
+func TestMain(m *testing.M) {
 	var (
 		err error
 		t   *jwt.Token
@@ -66,6 +67,8 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	os.Exit(m.Run())
 }
 
 func TestAuthorizationServer_handleToken(t *testing.T) {


### PR DESCRIPTION
We incorrectly looped over the values of a map, which in Go is in an indeterministic order. This lead to some confusion of KIDs, if multiple public keys were used. This in turn made some tests fail randomly.

Fixes #42
