### PR TITLE
feat: add user-aware token claims with preferred_username

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
@@ -45,10 +47,13 @@ jobs:
       - name: Test
         run: go test -v -coverprofile=coverage.cov -coverpkg ./... -covermode=atomic ./...
 
-      - uses: codecov/codecov-action@v2.1.0
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           files: coverage.cov
           flags: unittests
+          token: ${{ env.CODECOV_TOKEN }}
 
       - name: Push Release Docker Image
         run: |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,43 @@ docker run -p 8000:8000 ghcr.io/oxisto/oauth2go
 
 A login form is available on http://localhost:8000/login.
 
+## Custom claims
+
+`oauth2go` supports custom access-token claims through `WithTokenClaimsFunc`.
+
+- The callback receives `clientID` and `userID`.
+- `userID` is set for the authorization code flow (when the login integration is used).
+- `userID` is an empty string for client credentials.
+
+Current built-in user claims behavior:
+
+- If `userID` is present, access token `sub` is set to the user and `preferred_username` is included.
+- If `userID` is empty, `sub` is set to the client ID.
+- Refresh tokens keep `sub` as the client ID and include `preferred_username` when a user is present.
+
+Example:
+
+```golang
+srv := oauth2.NewServer(
+    ":8000",
+    oauth2.WithClient("client", "secret", "http://localhost/callback"),
+    login.WithLoginPage(login.WithUser("admin", "admin")),
+    oauth2.WithTokenClaimsFunc(func(clientID string, userID string) map[string]interface{} {
+        claims := map[string]any{
+            "tenant": "default",
+        }
+
+        if userID == "admin" {
+            claims["role"] = "admin"
+        }
+
+        return claims
+    }),
+)
+```
+
+Reserved claims (`sub`, `exp`, `preferred_username`, `nbf`, `iat`, `iss`, `aud`, `jti`) are controlled by the server and ignored if returned by the custom claims callback.
+
 
 ## (To be) Implemented Standards
 

--- a/login/authorize.go
+++ b/login/authorize.go
@@ -66,7 +66,7 @@ func (h *handler) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, fmt.Sprintf("%s?%s", path.Join(h.baseURL, "/login"), params.Encode()), http.StatusFound)
 	} else {
 		var params = url.Values{}
-		params.Add("code", h.srv.IssueCode(challenge))
+		params.Add("code", h.srv.IssueCode(challenge, session.User.Name))
 		params.Add("state", state)
 
 		http.Redirect(w, r, fmt.Sprintf("%s?%s", redirectURI, params.Encode()), http.StatusFound)

--- a/login/login.go
+++ b/login/login.go
@@ -119,9 +119,10 @@ func init() {
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method == "GET" {
+	switch r.Method {
+	case "GET":
 		h.doLoginGet(w, r)
-	} else if r.Method == "POST" {
+	case "POST":
 		h.doLoginPost(w, r)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -36,6 +36,7 @@ const (
 type codeInfo struct {
 	expiry    time.Time
 	challenge string
+	userID    string
 }
 
 // AuthorizationServer is an OAuth 2.0 authorization server
@@ -61,14 +62,19 @@ type AuthorizationServer struct {
 	// metadata contains server metadata according to RFC 8414. This is
 	// populated automatically.
 	metadata *ServerMetadata
+
+	// tokenClaimsFunc can optionally return custom claims for access tokens.
+	tokenClaimsFunc tokenClaimsFunc
 }
 
 type AuthorizationServerOption func(srv *AuthorizationServer)
 
 type signingKeysFunc func() (keys map[int]*ecdsa.PrivateKey)
 
+type tokenClaimsFunc func(clientID string, userID string) map[string]interface{}
+
 type CodeIssuer interface {
-	IssueCode(challenge string) string
+	IssueCode(challenge string, userID string) string
 	ValidateCode(verifier string, code string) bool
 }
 
@@ -101,6 +107,17 @@ func WithSigningKeysFunc(f signingKeysFunc) AuthorizationServerOption {
 func WithAllowedOrigins(origin string) AuthorizationServerOption {
 	return func(srv *AuthorizationServer) {
 		srv.allowedOrigin = origin
+	}
+}
+
+// WithTokenClaimsFunc sets a callback that can inject custom claims into
+// access tokens. The callback receives clientID and userID.
+//
+// The userID is set for the authorization code flow (when used with the
+// optional login package) and empty for client credentials.
+func WithTokenClaimsFunc(f func(clientID string, userID string) map[string]interface{}) AuthorizationServerOption {
+	return func(srv *AuthorizationServer) {
+		srv.tokenClaimsFunc = f
 	}
 }
 
@@ -194,7 +211,7 @@ func (srv *AuthorizationServer) doClientCredentialsFlow(w http.ResponseWriter, r
 		return
 	}
 
-	token, err = srv.GenerateToken(client.ClientID, 0, -1)
+	token, err = srv.GenerateToken(client.ClientID, "", 0, -1)
 	if err != nil {
 		http.Error(w, "error while creating JWT", http.StatusInternalServerError)
 		return
@@ -210,6 +227,7 @@ func (srv *AuthorizationServer) doAuthorizationCodeFlow(w http.ResponseWriter, r
 		err      error
 		code     string
 		verifier string
+		info     *codeInfo
 		token    *oauth2.Token
 		client   *Client
 	)
@@ -231,12 +249,17 @@ func (srv *AuthorizationServer) doAuthorizationCodeFlow(w http.ResponseWriter, r
 
 	// Retrieve the code
 	code = r.FormValue("code")
-	if !srv.ValidateCode(verifier, code) {
+	info, err = srv.consumeCode(verifier, code)
+	if err != nil {
+		Error(w, ErrorInvalidGrant, http.StatusBadRequest)
+		return
+	}
+	if info.userID == "" {
 		Error(w, ErrorInvalidGrant, http.StatusBadRequest)
 		return
 	}
 
-	token, err = srv.GenerateToken(client.ClientID, 0, 0)
+	token, err = srv.GenerateToken(client.ClientID, info.userID, 0, 0)
 	if err != nil {
 		http.Error(w, "error while creating JWT", http.StatusInternalServerError)
 		return
@@ -251,9 +274,12 @@ func (srv *AuthorizationServer) doRefreshTokenFlow(w http.ResponseWriter, r *htt
 	var (
 		err          error
 		refreshToken string
-		claims       jwt.RegisteredClaims
-		client       *Client
-		token        *Token
+		claims       struct {
+			jwt.RegisteredClaims
+			UserID string `json:"preferred_username,omitempty"`
+		}
+		client *Client
+		token  *Token
 	)
 
 	// Retrieve the token first, as we need it to find out which client this is
@@ -294,7 +320,7 @@ func (srv *AuthorizationServer) doRefreshTokenFlow(w http.ResponseWriter, r *htt
 	}
 
 issue:
-	token, err = srv.GenerateToken(client.ClientID, 0, -1)
+	token, err = srv.GenerateToken(client.ClientID, claims.UserID, 0, -1)
 	if err != nil {
 		http.Error(w, "error while creating JWT", http.StatusInternalServerError)
 		return
@@ -346,13 +372,14 @@ func (srv *AuthorizationServer) retrieveClient(r *http.Request, allowPublic bool
 	return nil, ErrClientNotFound
 }
 
-// IssueCode implements CodeIssuer.
-func (srv *AuthorizationServer) IssueCode(challenge string) (code string) {
+// IssueCode implements CodeIssuer and binds the code to a user.
+func (srv *AuthorizationServer) IssueCode(challenge string, userID string) (code string) {
 	code = GenerateSecret()
 
 	srv.codes[code] = &codeInfo{
 		expiry:    time.Now().Add(10 * time.Minute),
 		challenge: challenge,
+		userID:    userID,
 	}
 
 	return code
@@ -361,6 +388,12 @@ func (srv *AuthorizationServer) IssueCode(challenge string) (code string) {
 // ValidateCode implements CodeIssuer. It checks if the code exists and is
 // not expired. If the code exists, it will be invalidated after this call.
 func (srv *AuthorizationServer) ValidateCode(verifier string, code string) bool {
+	_, err := srv.consumeCode(verifier, code)
+
+	return err == nil
+}
+
+func (srv *AuthorizationServer) consumeCode(verifier string, code string) (*codeInfo, error) {
 	var (
 		ok   bool
 		info *codeInfo
@@ -368,35 +401,42 @@ func (srv *AuthorizationServer) ValidateCode(verifier string, code string) bool 
 
 	info, ok = srv.codes[code]
 	if !ok {
-		return false
+		return nil, errors.New("invalid code")
 	}
 
 	if info.expiry.Before(time.Now()) {
-		return false
+		return nil, errors.New("expired code")
 	}
 
 	var challenge = GenerateCodeChallenge(verifier)
 
 	// Check, if we need to check for a challenge
 	if info.challenge != "" && subtle.ConstantTimeCompare([]byte(challenge), []byte(info.challenge)) == 0 {
-		return false
+		return nil, errors.New("invalid challenge")
 	}
 
 	// Invalidate it
 	delete(srv.codes, code)
 
-	return true
+	return info, nil
 }
 
 // GenerateToken generates a Token (comprising at least an acesss token) for a specific client,
-// as specified by its ID. A signingKey needs to be specified, otherwise an error is thrown.
-// Optionally, if a refreshKey is specified, that key is used to also create a refresh token.
-func (srv *AuthorizationServer) GenerateToken(clientID string, signingKeyID int, refreshKeyID int) (token *Token, err error) {
+// as specified by its ID and optional userID. A signingKey needs to be specified, otherwise an
+// error is thrown. Optionally, if a refreshKey is specified, that key is used to also create a
+// refresh token.
+// The generated access token always has subject=clientID and can include user-specific
+// claims using the "preferred_username" claim and the optional custom claims callback.
+func (srv *AuthorizationServer) GenerateToken(clientID string, userID string, signingKeyID int, refreshKeyID int) (token *Token, err error) {
 	var (
 		expiry     = time.Now().Add(DefaultExpireIn)
 		signingKey *ecdsa.PrivateKey
 		refreshKey *ecdsa.PrivateKey
 		ok         bool
+		claims     = jwt.MapClaims{
+			"sub": clientID,
+			"exp": expiry.Unix(),
+		}
 	)
 
 	token = new(oauth2.Token)
@@ -409,27 +449,48 @@ func (srv *AuthorizationServer) GenerateToken(clientID string, signingKeyID int,
 		return nil, errors.New("invalid key ID")
 	}
 
+	// If we have a user ID, we add it as a claim. This will be populated by an
+	// authorization code, but not for client credentials.
+	if userID != "" {
+		claims["sub"] = userID
+		claims["preferred_username"] = userID
+	}
+
+	// Add custom claims, if we have a callback for that
+	if srv.tokenClaimsFunc != nil {
+		for k, v := range srv.tokenClaimsFunc(clientID, userID) {
+			switch k {
+			case "sub", "exp", "preferred_username", "nbf", "iat", "iss", "aud", "jti":
+				continue
+			default:
+				claims[k] = v
+			}
+		}
+	}
+
 	// Create a new JWT
-	t := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.RegisteredClaims{
-		Subject:   clientID,
-		ExpiresAt: jwt.NewNumericDate(expiry),
-	})
+	t := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
 	t.Header["kid"] = fmt.Sprintf("%d", signingKeyID)
 
 	if token.AccessToken, err = t.SignedString(signingKey); err != nil {
 		return nil, err
 	}
 
-	// Create a refresh token, if we have a key for it
+	// Create a refresh token, if we have a key for it.
 	if refreshKeyID != -1 {
 		refreshKey, ok = srv.signingKeys[refreshKeyID]
 		if !ok {
 			return nil, errors.New("invalid key ID")
 		}
 
-		t = jwt.NewWithClaims(jwt.SigningMethodES256, jwt.RegisteredClaims{
-			Subject: clientID,
-		})
+		refreshClaims := jwt.MapClaims{
+			"sub": clientID,
+		}
+		if userID != "" {
+			refreshClaims["preferred_username"] = userID
+		}
+
+		t = jwt.NewWithClaims(jwt.SigningMethodES256, refreshClaims)
 		t.Header["kid"] = fmt.Sprintf("%d", refreshKeyID)
 
 		if token.RefreshToken, err = t.SignedString(refreshKey); err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -476,6 +477,35 @@ func TestAuthorizationServer_doAuthorizationCodeFlow(t *testing.T) {
 			wantBody: `{"error": "invalid_request"}`,
 		},
 		{
+			name: "authorization code without user binding",
+			fields: fields{
+				clients: []*Client{
+					{
+						ClientID:     "client",
+						ClientSecret: "secret",
+					},
+				},
+				codes: map[string]*codeInfo{
+					"myCode": {
+						expiry:    time.Now().Add(10 * time.Minute),
+						challenge: testChallenge,
+					},
+				},
+			},
+			args: args{
+				r: &http.Request{
+					Method: "POST",
+					Header: http.Header{
+						http.CanonicalHeaderKey("Authorization"): []string{"Basic Y2xpZW50OnNlY3JldA=="}, // client:secret
+						http.CanonicalHeaderKey("Content-Type"):  []string{"application/x-www-form-urlencoded"},
+					},
+					Body: io.NopCloser(strings.NewReader(fmt.Sprintf("code=myCode&code_verifier=%s", testVerifier))),
+				},
+			},
+			wantCode: http.StatusBadRequest,
+			wantBody: `{"error": "invalid_grant"}`,
+		},
+		{
 			name: "problem with JWT",
 			fields: fields{
 				clients: []*Client{
@@ -488,6 +518,7 @@ func TestAuthorizationServer_doAuthorizationCodeFlow(t *testing.T) {
 					"myCode": {
 						expiry:    time.Now().Add(10 * time.Minute),
 						challenge: testChallenge,
+						userID:    "admin",
 					},
 				},
 				signingKeys: map[int]*ecdsa.PrivateKey{
@@ -860,7 +891,7 @@ func TestAuthorizationServer_GenerateToken(t *testing.T) {
 				codes:       tt.fields.codes,
 			}
 
-			gotToken, err := srv.GenerateToken(tt.args.clientID, tt.args.signingKeyID, tt.args.refreshKeyID)
+			gotToken, err := srv.GenerateToken(tt.args.clientID, "", tt.args.signingKeyID, tt.args.refreshKeyID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AuthorizationServer.GenerateToken() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -868,6 +899,230 @@ func TestAuthorizationServer_GenerateToken(t *testing.T) {
 
 			if !reflect.DeepEqual(gotToken, tt.wantToken) {
 				t.Errorf("AuthorizationServer.GenerateToken() = %v, want %v", gotToken, tt.wantToken)
+			}
+		})
+	}
+}
+
+func TestAuthorizationServer_GenerateToken_CustomClaims(t *testing.T) {
+	type fields struct {
+		signingKeys     map[int]*ecdsa.PrivateKey
+		tokenClaimsFunc tokenClaimsFunc
+	}
+	type args struct {
+		clientID     string
+		userID       string
+		signingKeyID int
+		refreshKeyID int
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantClaims map[string]interface{}
+	}{
+		{
+			name: "custom claims with reserved overrides ignored",
+			fields: fields{
+				signingKeys: map[int]*ecdsa.PrivateKey{
+					0: testSigningKey,
+				},
+				tokenClaimsFunc: func(clientID string, userID string) map[string]interface{} {
+					claims := map[string]interface{}{
+						"tenant": "default",
+					}
+
+					if userID == "alice" {
+						claims["role"] = "admin"
+					}
+
+					// This should be ignored by GenerateToken.
+					claims["sub"] = "malicious"
+
+					return claims
+				},
+			},
+			args: args{
+				clientID:     "client",
+				userID:       "alice",
+				signingKeyID: 0,
+				refreshKeyID: -1,
+			},
+			wantClaims: map[string]interface{}{
+				"sub":                "alice",
+				"preferred_username": "alice",
+				"tenant":             "default",
+				"role":               "admin",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := &AuthorizationServer{
+				signingKeys:     tt.fields.signingKeys,
+				tokenClaimsFunc: tt.fields.tokenClaimsFunc,
+			}
+
+			token, err := srv.GenerateToken(tt.args.clientID, tt.args.userID, tt.args.signingKeyID, tt.args.refreshKeyID)
+			if err != nil {
+				t.Fatalf("GenerateToken() error = %v", err)
+			}
+
+			claims := jwt.MapClaims{}
+			_, err = jwt.ParseWithClaims(token.AccessToken, claims, func(t *jwt.Token) (interface{}, error) {
+				kid, _ := strconv.ParseInt(t.Header["kid"].(string), 10, 64)
+
+				return &srv.signingKeys[int(kid)].PublicKey, nil
+			})
+			if err != nil {
+				t.Fatalf("ParseWithClaims() error = %v", err)
+			}
+
+			for key, want := range tt.wantClaims {
+				if claims[key] != want {
+					t.Fatalf("access token %s = %v, want %v", key, claims[key], want)
+				}
+			}
+		})
+	}
+}
+
+func TestAuthorizationServer_GenerateToken_CustomClaimsViaOption(t *testing.T) {
+	srv := NewServer(":0",
+		WithSigningKeysFunc(func() map[int]*ecdsa.PrivateKey {
+			return map[int]*ecdsa.PrivateKey{0: testSigningKey}
+		}),
+		WithTokenClaimsFunc(func(clientID string, userID string) map[string]interface{} {
+			claims := map[string]interface{}{}
+
+			if userID == "" {
+				claims["flow"] = "client"
+			} else {
+				claims["flow"] = "user"
+			}
+
+			// Must be ignored by server-controlled reserved claims logic.
+			claims["sub"] = "override"
+
+			return claims
+		}),
+	)
+
+	tests := []struct {
+		name          string
+		userID        string
+		wantSub       string
+		wantFlow      string
+		wantPreferred bool
+	}{
+		{
+			name:          "user flow",
+			userID:        "alice",
+			wantSub:       "alice",
+			wantFlow:      "user",
+			wantPreferred: true,
+		},
+		{
+			name:          "client flow",
+			userID:        "",
+			wantSub:       "client",
+			wantFlow:      "client",
+			wantPreferred: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := srv.GenerateToken("client", tt.userID, 0, -1)
+			if err != nil {
+				t.Fatalf("GenerateToken() error = %v", err)
+			}
+
+			claims := jwt.MapClaims{}
+			_, err = jwt.ParseWithClaims(token.AccessToken, claims, func(t *jwt.Token) (interface{}, error) {
+				kid, _ := strconv.ParseInt(t.Header["kid"].(string), 10, 64)
+
+				return &srv.signingKeys[int(kid)].PublicKey, nil
+			})
+			if err != nil {
+				t.Fatalf("ParseWithClaims() error = %v", err)
+			}
+
+			if claims["sub"] != tt.wantSub {
+				t.Fatalf("access token sub = %v, want %v", claims["sub"], tt.wantSub)
+			}
+
+			if claims["flow"] != tt.wantFlow {
+				t.Fatalf("access token flow = %v, want %v", claims["flow"], tt.wantFlow)
+			}
+
+			_, hasPreferred := claims["preferred_username"]
+			if hasPreferred != tt.wantPreferred {
+				t.Fatalf("access token preferred_username presence = %v, want %v", hasPreferred, tt.wantPreferred)
+			}
+		})
+	}
+}
+
+func TestAuthorizationServer_GenerateToken_RefreshClaimsForUser(t *testing.T) {
+	type fields struct {
+		signingKeys map[int]*ecdsa.PrivateKey
+	}
+	type args struct {
+		clientID string
+		userID   string
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		wantSub       string
+		wantPreferred string
+	}{
+		{
+			name: "refresh token has user claim when user provided",
+			fields: fields{
+				signingKeys: map[int]*ecdsa.PrivateKey{
+					0: testSigningKey,
+				},
+			},
+			args: args{
+				clientID: "client",
+				userID:   "alice",
+			},
+			wantSub:       "client",
+			wantPreferred: "alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := &AuthorizationServer{
+				signingKeys: tt.fields.signingKeys,
+			}
+
+			token, err := srv.GenerateToken(tt.args.clientID, tt.args.userID, 0, 0)
+			if err != nil {
+				t.Fatalf("GenerateToken() error = %v", err)
+			}
+
+			claims := jwt.MapClaims{}
+			_, err = jwt.ParseWithClaims(token.RefreshToken, claims, func(t *jwt.Token) (interface{}, error) {
+				kid, _ := strconv.ParseInt(t.Header["kid"].(string), 10, 64)
+
+				return &srv.signingKeys[int(kid)].PublicKey, nil
+			})
+			if err != nil {
+				t.Fatalf("ParseWithClaims(refresh) error = %v", err)
+			}
+
+			if claims["sub"] != tt.wantSub {
+				t.Fatalf("refresh token sub = %v, want %v", claims["sub"], tt.wantSub)
+			}
+
+			if claims["preferred_username"] != tt.wantPreferred {
+				t.Fatalf("refresh token preferred_username = %v, want %v", claims["preferred_username"], tt.wantPreferred)
 			}
 		})
 	}


### PR DESCRIPTION
- add custom claim callback support via WithTokenClaimsFunc
- bind auth codes to users and require user for authorization_code exchange
- set access token sub to user when present, otherwise client
- document claims behavior and add table-driven claim tests
